### PR TITLE
feat(auth): connexion directe pour admin/superadmin (suppression MFA …

### DIFF
--- a/Front_End/CODE-REACT/src/views/auth/lock-screen.jsx
+++ b/Front_End/CODE-REACT/src/views/auth/lock-screen.jsx
@@ -16,7 +16,6 @@ const LockScreen = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [pending, setPending] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -24,14 +23,12 @@ const LockScreen = () => {
     setLoading(true);
     try {
       const data = await authApi.login(email || "admin@medifollow.com", password);
-      if (data.pending) {
-        setPending(true);
-      } else {
-        localStorage.setItem("adminToken", data.access_token);
-        localStorage.setItem("adminUser", JSON.stringify(data.user || { email, role: "admin" }));
-        navigate("/admin/dashboard");
-        window.location.reload();
-      }
+      localStorage.setItem("adminToken", data.access_token);
+      localStorage.setItem("adminUser", JSON.stringify(data.user || { email, role: "admin" }));
+      const role = data.user?.role;
+      const redirectPath = role === "superadmin" ? "/super-admin/dashboard" : "/admin/dashboard";
+      navigate(redirectPath);
+      window.location.reload();
     } catch (err) {
       setError(err.message || t("lockScreen.loginFailed"));
     } finally {
@@ -84,24 +81,11 @@ const LockScreen = () => {
                 <h4 className="mt-3 mb-0">{t("lockScreen.pageTitle")}</h4>
                 <p>{t("lockScreen.intro")}</p>
                 <Form className="mt-0" onSubmit={handleSubmit}>
-                  {pending && (
-                    <div className="alert alert-success py-2" role="alert">
-                      <i className="ri-mail-line me-2"></i>
-                      {t("lockScreen.pendingEmailCheck")}
-                    </div>
-                  )}
                   {error && (
                     <div className="alert alert-danger py-2" role="alert">
                       {error}
                     </div>
                   )}
-                  {pending && (
-                    <button type="button" className="btn btn-outline-secondary mt-2" onClick={() => { setPending(false); }}>
-                      {t("lockScreen.retryOtherLogin")}
-                    </button>
-                  )}
-                  {!pending && (
-                  <>
                   <Form.Group className="form-group mb-3" controlId="email">
                     <Form.Label className="mb-2">{t("lockScreen.email")}</Form.Label>
                     <Form.Control
@@ -143,8 +127,6 @@ const LockScreen = () => {
                       {loading ? t("lockScreen.signingIn") : t("lockScreen.signInButton")}
                     </button>
                   </div>
-                  </>
-                  )}
                   <div className="sign-info mt-3">
                     <span className="dark-color d-inline-block">
                       <Link to="/auth/sign-in">{t("lockScreen.userSignInLink")}</Link>

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   Injectable,
+  Logger,
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
@@ -31,6 +32,7 @@ const {
 
 @Injectable()
 export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
   constructor(
     @InjectModel(User.name) private userModel: Model<User>,
     @InjectModel(LoginAttempt.name) private loginAttemptModel: Model<LoginAttempt>,
@@ -563,22 +565,20 @@ export class AuthService {
       throw new UnauthorizedException('Accès administrateur requis');
     }
 
-    const token = this.emailService.generateToken();
-    const expiresAt = new Date(Date.now() + 15 * 60 * 1000);
-    await this.loginAttemptModel.create({
-      userId: user._id.toString(),
-      token,
-      email: user.email,
-      used: false,
-      expiresAt,
-    });
-
-    await this.emailService.sendLoginConfirmation(user.email, token, user.name);
-
+    const payload = { sub: user._id, email: user.email, role: user.role };
+    const u = user.toObject();
     return {
-      pending: true,
-      message: 'Un lien de confirmation a été envoyé à votre adresse email. Cliquez dessus pour accéder à votre session.',
-      email: user.email,
+      access_token: this.jwtService.sign(payload),
+      user: {
+        id: u._id,
+        email: u.email,
+        name: u.name,
+        role: u.role,
+        profileImage: u.profileImage,
+        alternateEmail: u.alternateEmail,
+        languages: u.languages || [],
+        socialMedia: u.socialMedia || {},
+      },
     };
   }
 

--- a/backend/src/auth/email.service.ts
+++ b/backend/src/auth/email.service.ts
@@ -22,6 +22,11 @@ export class EmailService {
         secure: port === 465,
         requireTLS: port !== 465,
         auth: { user, pass },
+        // Timeouts courts : en prod (Render/Vercel/etc.) on préfère échouer vite
+        // plutôt que laisser une requête HTTP pendre 10 minutes.
+        connectionTimeout: 10_000,
+        greetingTimeout: 10_000,
+        socketTimeout: 15_000,
       });
       if (isGmail) {
         const fromEmail = this.extractEmailFromFromHeader(process.env.SMTP_FROM || '');


### PR DESCRIPTION
…email)

La route POST /api/auth/login renvoie maintenant directement {access_token, user}, comme les autres roles. Plus de blocage du sign-in en prod quand SMTP est lent ou indisponible. Ajout de timeouts SMTP et nettoyage UI lock-screen.